### PR TITLE
Return type annotation update suggestion

### DIFF
--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -114,7 +114,7 @@ class Criteria
      *
      * @param Expression $expression
      *
-     * @return Criteria
+     * @return $this
      */
     public function where(Expression $expression)
     {
@@ -129,7 +129,7 @@ class Criteria
      *
      * @param Expression $expression
      *
-     * @return Criteria
+     * @return $this
      */
     public function andWhere(Expression $expression)
     {
@@ -150,7 +150,7 @@ class Criteria
      *
      * @param Expression $expression
      *
-     * @return Criteria
+     * @return $this
      */
     public function orWhere(Expression $expression)
     {
@@ -195,7 +195,7 @@ class Criteria
      *
      * @param string[] $orderings
      *
-     * @return Criteria
+     * @return $this
      */
     public function orderBy(array $orderings)
     {
@@ -224,7 +224,7 @@ class Criteria
      *
      * @param int|null $firstResult The value to set.
      *
-     * @return Criteria
+     * @return $this
      */
     public function setFirstResult($firstResult)
     {
@@ -248,7 +248,7 @@ class Criteria
      *
      * @param int|null $maxResults The value to set.
      *
-     * @return Criteria
+     * @return $this
      */
     public function setMaxResults($maxResults)
     {


### PR DESCRIPTION
Updating the return type annotation would allow IDEs to asses methods available through the returned value, if the base Criteria class is extended upon.
Otherwise it would generate a notification error if the methods are chained.
